### PR TITLE
Add export-command option for immediate profile update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.0] - 2025-06-11
+### Added
+- `--export-command` option prints the shell command to apply the profile
+### Changed
+- README instructions updated; shell configs are no longer sourced automatically
+
 ## [1.1.0] - 2025-06-10
 ### Added
 - Automatically source the appropriate shell rc file after profile update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.1] - 2025-06-11
+### Changed
+- CLI prints the export command by default; `--export-command` is no longer required
+
 ## [1.2.0] - 2025-06-11
 ### Added
 - `--export-command` option prints the shell command to apply the profile

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project has evolved through several iterations:
 - Updates your shell configuration file to set the selected profile as the default
 - Creates backup files before modifying your configuration
 - Ensures idempotency (no duplicate modifications if selecting the same profile)
-- Automatically reloads your shell configuration after updating
+- Provides a shell command for immediate application using `--export-command`
 - Provides clear logging of operations
 - Handles errors gracefully with informative messages
 - Supports case-insensitive profile name matching
@@ -60,6 +60,12 @@ Simply run the command:
 
 ```bash
 awspick
+```
+
+To apply the profile immediately in your current shell, run:
+
+```bash
+eval "$(awspick --export-command)"
 ```
 
 This will:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project has evolved through several iterations:
 - Updates your shell configuration file to set the selected profile as the default
 - Creates backup files before modifying your configuration
 - Ensures idempotency (no duplicate modifications if selecting the same profile)
-- Provides a shell command for immediate application using `--export-command`
+- Prints a shell command for immediate application
 - Provides clear logging of operations
 - Handles errors gracefully with informative messages
 - Supports case-insensitive profile name matching
@@ -65,7 +65,7 @@ awspick
 To apply the profile immediately in your current shell, run:
 
 ```bash
-eval "$(awspick --export-command)"
+eval "$(awspick)"
 ```
 
 This will:

--- a/aws_pick.py
+++ b/aws_pick.py
@@ -10,7 +10,8 @@ Usage:
 """
 
 import sys
+
 from aws_pick.cli import main
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/aws_pick/cli.py
+++ b/aws_pick/cli.py
@@ -33,10 +33,11 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse command-line arguments."""
 
     parser = argparse.ArgumentParser(description="AWS profile picker")
+    # Deprecated option kept for backward compatibility but ignored
     parser.add_argument(
         "--export-command",
         action="store_true",
-        help="Print shell command to set AWS_PROFILE",
+        help=argparse.SUPPRESS,
     )
     return parser.parse_args(argv)
 
@@ -125,12 +126,9 @@ def main(argv: Optional[List[str]] = None) -> int:
 
         export_cmd = generate_export_command(profile, shell_name)
 
-        if args.export_command:
-            print(export_cmd)
-        else:
-            print(
-                "Run 'eval \"$(awspick --export-command)\"' to apply to the current shell"
-            )
+        # Always print the export command so the user can eval the output
+        print(export_cmd)
+        print("Run 'eval \"$(awspick)\"' to apply in the current shell")
 
         return 0
 

--- a/aws_pick/shell.py
+++ b/aws_pick/shell.py
@@ -281,3 +281,10 @@ def source_rc_file(shell_config: ShellConfig) -> bool:
     except Exception as e:
         logger.error(f"Failed to source rc file: {e}")
         return False
+
+
+def generate_export_command(profile_name: str, shell_name: str = None) -> str:
+    """Return the shell command to export AWS_PROFILE for the given shell."""
+
+    _, shell_config = get_rc_path(shell_name)
+    return shell_config.get_profile_line(profile_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-pick"
-version = "1.1.0"
+version = "1.2.0"
 description = "A simple CLI tool to easily switch between AWS profiles in your shell environment"
 authors = ["kkamji <kkamji@example.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-pick"
-version = "1.2.0"
+version = "1.2.1"
 description = "A simple CLI tool to easily switch between AWS profiles in your shell environment"
 authors = ["kkamji <kkamji@example.com>"]
 readme = "README.md"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,7 +182,7 @@ def test_main_failed_update(
 @patch("aws_pick.cli.update_aws_profile")
 @patch("aws_pick.cli.detect_shell")
 @patch("builtins.print")
-def test_main_export_command(
+def test_main_outputs_export_command(
     mock_print,
     mock_detect_shell,
     mock_update,
@@ -190,14 +190,14 @@ def test_main_export_command(
     mock_display,
     mock_read_profiles,
 ):
-    """Test printing export command for current shell."""
+    """Test export command is printed by default."""
 
     mock_read_profiles.return_value = ["default", "dev", "prod"]
     mock_get_selection.return_value = "dev"
     mock_update.return_value = (True, None)
     mock_detect_shell.return_value = "bash"
 
-    result = main(["--export-command"])
+    result = main([])
 
     assert result == 0
     mock_print.assert_any_call('export AWS_PROFILE="dev"')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,7 @@ def test_main_no_profiles(mock_read_profiles):
     mock_read_profiles.return_value = []
 
     # Call function
-    result = main()
+    result = main([])
 
     # Assertions
     assert result == 1
@@ -108,7 +108,7 @@ def test_main_cancelled_selection(mock_get_selection, mock_display, mock_read_pr
     mock_get_selection.return_value = None
 
     # Call function
-    result = main()
+    result = main([])
 
     # Assertions
     assert result == 1
@@ -139,7 +139,7 @@ def test_main_successful_update(
     mock_detect_shell.return_value = "bash"
 
     # Call function
-    result = main()
+    result = main([])
 
     # Assertions
     assert result == 0
@@ -166,7 +166,7 @@ def test_main_failed_update(
     mock_detect_shell.return_value = "bash"
 
     # Call function
-    result = main()
+    result = main([])
 
     # Assertions
     assert result == 1
@@ -174,3 +174,30 @@ def test_main_failed_update(
     mock_display.assert_called_once()
     mock_get_selection.assert_called_once()
     mock_update.assert_called_once_with("dev", "bash")
+
+
+@patch("aws_pick.cli.read_aws_profiles")
+@patch("aws_pick.cli.display_profiles")
+@patch("aws_pick.cli.get_profile_selection")
+@patch("aws_pick.cli.update_aws_profile")
+@patch("aws_pick.cli.detect_shell")
+@patch("builtins.print")
+def test_main_export_command(
+    mock_print,
+    mock_detect_shell,
+    mock_update,
+    mock_get_selection,
+    mock_display,
+    mock_read_profiles,
+):
+    """Test printing export command for current shell."""
+
+    mock_read_profiles.return_value = ["default", "dev", "prod"]
+    mock_get_selection.return_value = "dev"
+    mock_update.return_value = (True, None)
+    mock_detect_shell.return_value = "bash"
+
+    result = main(["--export-command"])
+
+    assert result == 0
+    mock_print.assert_any_call('export AWS_PROFILE="dev"')

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -12,6 +12,7 @@ from aws_pick.shell import (
     ShellConfig,
     backup_rc_file,
     detect_shell,
+    generate_export_command,
     get_rc_path,
     get_shell_configs,
     update_aws_profile,
@@ -285,3 +286,15 @@ def test_update_aws_profile_no_rc_file_fish(
         call_args[0][0] for call_args in handle.write.call_args_list
     )
     assert "# Created by AWS Pick" in written_content
+
+
+def test_generate_export_command():
+    """Test generating export command for different shells."""
+
+    bash_cmd = generate_export_command("dev", "bash")
+    zsh_cmd = generate_export_command("dev", "zsh")
+    fish_cmd = generate_export_command("dev", "fish")
+
+    assert bash_cmd == 'export AWS_PROFILE="dev"'
+    assert zsh_cmd == 'export AWS_PROFILE="dev"'
+    assert fish_cmd == 'set -gx AWS_PROFILE "dev"'


### PR DESCRIPTION
## Summary
- add `generate_export_command` helper
- add CLI `--export-command` option
- update README and CHANGELOG for new workflow
- bump version to 1.2.0
- add unit tests for new logic

## Testing
- `poetry run isort aws_pick.py aws_pick/cli.py aws_pick/shell.py tests/test_cli.py tests/test_shell.py`
- `poetry run black aws_pick.py aws_pick/cli.py aws_pick/shell.py tests/test_cli.py tests/test_shell.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554da0b350832098d7f78880cb28a5